### PR TITLE
Add support for Bazel build system

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_prefix")
+
+go_prefix("github.com/ckitagawa/go-gnuplot")
+
+load("@io_bazel_rules_go//go:def.bzl", "gazelle")
+
+gazelle(
+    name = "gazelle",
+    prefix = "github.com/ckitagawa/go-gnuplot",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["gnuplot.go"],
+    visibility = ["//visibility:public"],
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,13 @@
+git_repository(
+    name = "io_bazel_rules_go",
+    remote = "https://github.com/bazelbuild/rules_go.git",
+    tag = "0.5.4",
+)
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_repositories",
+    "go_repository",
+)
+
+go_repositories()

--- a/bazel-bin
+++ b/bazel-bin
@@ -1,0 +1,1 @@
+/home/ckitagawa/.cache/bazel/_bazel_ckitagawa/9f34bb55d42206a2825b3b83aa926a0e/execroot/__main__/bazel-out/local-fastbuild/bin

--- a/bazel-genfiles
+++ b/bazel-genfiles
@@ -1,0 +1,1 @@
+/home/ckitagawa/.cache/bazel/_bazel_ckitagawa/9f34bb55d42206a2825b3b83aa926a0e/execroot/__main__/bazel-out/local-fastbuild/genfiles

--- a/bazel-go-gnuplot
+++ b/bazel-go-gnuplot
@@ -1,0 +1,1 @@
+/home/ckitagawa/.cache/bazel/_bazel_ckitagawa/9f34bb55d42206a2825b3b83aa926a0e/execroot/__main__

--- a/bazel-out
+++ b/bazel-out
@@ -1,0 +1,1 @@
+/home/ckitagawa/.cache/bazel/_bazel_ckitagawa/9f34bb55d42206a2825b3b83aa926a0e/execroot/__main__/bazel-out

--- a/bazel-testlogs
+++ b/bazel-testlogs
@@ -1,0 +1,1 @@
+/home/ckitagawa/.cache/bazel/_bazel_ckitagawa/9f34bb55d42206a2825b3b83aa926a0e/execroot/__main__/bazel-out/local-fastbuild/testlogs

--- a/examples/ex1/BUILD.bazel
+++ b/examples/ex1/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["t001.go"],
+    visibility = ["//visibility:private"],
+    deps = ["//:go_default_library"],
+)
+
+go_binary(
+    name = "ex1",
+    library = ":go_default_library",
+    visibility = ["//visibility:public"],
+)

--- a/examples/ex1/t001.go
+++ b/examples/ex1/t001.go
@@ -1,9 +1,9 @@
 package main
 
-import "fmt"
-
-//import "io/ioutil"
-import "github.com/sbinet/go-gnuplot"
+import (
+	"fmt"
+	"github.com/ckitagawa/go-gnuplot"
+)
 
 func main() {
 	fname := ""
@@ -17,13 +17,13 @@ func main() {
 	}
 	defer p.Close()
 
-	p.PlotX([]float64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, "some data")
+	p.CheckedCmd("plot %f*x", 23.0)
+	p.CheckedCmd("plot %f * cos(%f * x)", 32.0, -3.0)
 	p.CheckedCmd("set terminal pdf")
-	p.CheckedCmd("set output 'plot002.pdf'")
+	p.CheckedCmd("set output 'plot001.pdf'")
 	p.CheckedCmd("replot")
 
 	p.CheckedCmd("q")
+
 	return
 }
-
-/* EOF */

--- a/examples/ex2/BUILD.bazel
+++ b/examples/ex2/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["t002.go"],
+    visibility = ["//visibility:private"],
+    deps = ["//:go_default_library"],
+)
+
+go_binary(
+    name = "ex2",
+    library = ":go_default_library",
+    visibility = ["//visibility:public"],
+)

--- a/examples/ex2/t002.go
+++ b/examples/ex2/t002.go
@@ -1,9 +1,9 @@
 package main
 
-import "fmt"
-
-//import "io/ioutil"
-import "github.com/sbinet/go-gnuplot"
+import (
+	"fmt"
+	"github.com/ckitagawa/go-gnuplot"
+)
 
 func main() {
 	fname := ""
@@ -17,17 +17,11 @@ func main() {
 	}
 	defer p.Close()
 
-	p.CheckedCmd("plot %f*x", 23.0)
-	p.CheckedCmd("plot %f * cos(%f * x)", 32.0, -3.0)
-	//p.CheckedCmd("save foo.ps")
+	p.PlotX([]float64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, "some data")
 	p.CheckedCmd("set terminal pdf")
-	p.CheckedCmd("set output 'plot001.pdf'")
+	p.CheckedCmd("set output 'plot002.pdf'")
 	p.CheckedCmd("replot")
 
 	p.CheckedCmd("q")
-	//p.proc.Wait(0)
-
 	return
 }
-
-/* EOF */

--- a/examples/ex3/BUILD.bazel
+++ b/examples/ex3/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["t003.go"],
+    visibility = ["//visibility:private"],
+    deps = ["//:go_default_library"],
+)
+
+go_binary(
+    name = "ex3",
+    library = ":go_default_library",
+    visibility = ["//visibility:public"],
+)

--- a/examples/ex3/t003.go
+++ b/examples/ex3/t003.go
@@ -1,7 +1,9 @@
 package main
 
-import "fmt"
-import "github.com/sbinet/go-gnuplot"
+import (
+	"fmt"
+	"github.com/ckitagawa/go-gnuplot"
+)
 
 func main() {
 	fname := ""
@@ -26,5 +28,3 @@ func main() {
 	p.CheckedCmd("q")
 	return
 }
-
-/* EOF */

--- a/examples/ex3_surf/BUILD.bazel
+++ b/examples/ex3_surf/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["t003_splot.go"],
+    visibility = ["//visibility:private"],
+    deps = ["//:go_default_library"],
+)
+
+go_binary(
+    name = "ex3_surf",
+    library = ":go_default_library",
+    visibility = ["//visibility:public"],
+)

--- a/examples/ex3_surf/t003_splot.go
+++ b/examples/ex3_surf/t003_splot.go
@@ -1,8 +1,9 @@
 package main
 
-import "fmt"
-import "github.com/sbinet/go-gnuplot"
-import "math"
+import (
+	"fmt"
+	"github.com/ckitagawa/go-gnuplot"
+)
 
 func main() {
 	fname := ""
@@ -16,18 +17,17 @@ func main() {
 	}
 	defer p.Close()
 
-	p.SetStyle("steps")
-	p.PlotFunc([]float64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-		func(x float64) float64 { return math.Exp(float64(x) + 2.) },
-		"test plot-func")
+	p.SetPlotCmd("splot")
+	p.SetStyle("pm3d")
+
+	p.PlotXY([]float64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		[]float64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, "some data - x/y")
 	p.SetXLabel("my x data")
 	p.SetYLabel("my y data")
 	p.CheckedCmd("set terminal pdf")
-	p.CheckedCmd("set output 'plot004.pdf'")
+	p.CheckedCmd("set output 'plot003.pdf'")
 	p.CheckedCmd("replot")
 
 	p.CheckedCmd("q")
 	return
 }
-
-/* EOF */

--- a/examples/ex4/BUILD.bazel
+++ b/examples/ex4/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["t004.go"],
+    visibility = ["//visibility:private"],
+    deps = ["//:go_default_library"],
+)
+
+go_binary(
+    name = "ex4",
+    library = ":go_default_library",
+    visibility = ["//visibility:public"],
+)

--- a/examples/ex4/t004.go
+++ b/examples/ex4/t004.go
@@ -1,7 +1,10 @@
 package main
 
-import "fmt"
-import "github.com/sbinet/go-gnuplot"
+import (
+	"fmt"
+	"github.com/ckitagawa/go-gnuplot"
+	"math"
+)
 
 func main() {
 	fname := ""
@@ -15,19 +18,16 @@ func main() {
 	}
 	defer p.Close()
 
-	p.SetPlotCmd("splot")
-	p.SetStyle("pm3d")
-
-	p.PlotXY([]float64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-		[]float64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, "some data - x/y")
+	p.SetStyle("steps")
+	p.PlotFunc([]float64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		func(x float64) float64 { return math.Exp(float64(x) + 2.) },
+		"test plot-func")
 	p.SetXLabel("my x data")
 	p.SetYLabel("my y data")
 	p.CheckedCmd("set terminal pdf")
-	p.CheckedCmd("set output 'plot003.pdf'")
+	p.CheckedCmd("set output 'plot004.pdf'")
 	p.CheckedCmd("replot")
 
 	p.CheckedCmd("q")
 	return
 }
-
-/* EOF */

--- a/examples/ex5/BUILD.bazel
+++ b/examples/ex5/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["t005.go"],
+    visibility = ["//visibility:private"],
+    deps = ["//:go_default_library"],
+)
+
+go_binary(
+    name = "ex5",
+    library = ":go_default_library",
+    visibility = ["//visibility:public"],
+)

--- a/examples/ex5/t005.go
+++ b/examples/ex5/t005.go
@@ -1,7 +1,9 @@
 package main
 
-import "fmt"
-import "github.com/sbinet/go-gnuplot"
+import (
+	"fmt"
+	"github.com/ckitagawa/go-gnuplot"
+)
 
 func main() {
 	fname := ""
@@ -18,18 +20,16 @@ func main() {
 	p.CheckedCmd("set grid x")
 	p.CheckedCmd("set grid y")
 	p.CheckedCmd("set grid z")
-	p.PlotNd(
-		"test Nd plot",
+	p.PlotXYZ(
 		[]float64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
 		[]float64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-		[]float64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10})
+		[]float64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		"test 3d plot")
 	p.SetLabels("x", "y", "z")
 	p.CheckedCmd("set terminal pdf")
-	p.CheckedCmd("set output 'plot006.pdf'")
+	p.CheckedCmd("set output 'plot005.pdf'")
 	p.CheckedCmd("replot")
 
 	p.CheckedCmd("q")
 	return
 }
-
-/* EOF */

--- a/examples/ex6/BUILD.bazel
+++ b/examples/ex6/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["t006.go"],
+    visibility = ["//visibility:private"],
+    deps = ["//:go_default_library"],
+)
+
+go_binary(
+    name = "ex6",
+    library = ":go_default_library",
+    visibility = ["//visibility:public"],
+)

--- a/examples/ex6/t006.go
+++ b/examples/ex6/t006.go
@@ -1,7 +1,9 @@
 package main
 
-import "fmt"
-import "github.com/sbinet/go-gnuplot"
+import (
+	"fmt"
+	"github.com/ckitagawa/go-gnuplot"
+)
 
 func main() {
 	fname := ""
@@ -18,18 +20,16 @@ func main() {
 	p.CheckedCmd("set grid x")
 	p.CheckedCmd("set grid y")
 	p.CheckedCmd("set grid z")
-	p.PlotXYZ(
+	p.PlotNd(
+		"test Nd plot",
 		[]float64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
 		[]float64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-		[]float64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-		"test 3d plot")
+		[]float64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10})
 	p.SetLabels("x", "y", "z")
 	p.CheckedCmd("set terminal pdf")
-	p.CheckedCmd("set output 'plot005.pdf'")
+	p.CheckedCmd("set output 'plot006.pdf'")
 	p.CheckedCmd("replot")
 
 	p.CheckedCmd("q")
 	return
 }
-
-/* EOF */

--- a/gnuplot.go
+++ b/gnuplot.go
@@ -330,17 +330,16 @@ func (self *Plotter) SetPlotCmd(cmd string) (err error) {
 // 		"pm3d"
 func (self *Plotter) SetStyle(style string) (err error) {
 	allowed := []string{
-		"lines", 
-		"points", 
+		"lines",
+		"points",
 		"linespoints",
-		"impulses", 
+		"impulses",
 		"dots",
 		"steps",
 		"errorbars",
 		"boxes",
 		"boxerrorbars",
-		"pm3d"
-	}
+		"pm3d"}
 
 	for _, s := range allowed {
 		if s == style {


### PR DESCRIPTION
Add support for the [Bazel](https://bazel.build/) build system. 

Also:
- Restructure example directory structure
- Fix typo from when linespoints was fixed
- Add [Gazelle](https://github.com/bazelbuild/rules_go/tree/master/go/tools/gazelle) support